### PR TITLE
Bump dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,13 +4,13 @@ cffi==1.12.3
 Click==7.0
 dataclasses==0.6; python_version < '3.7'
 greenlet==0.4.13
-hypothesis==4.32.2
+hypothesis==4.36.2
 immutables==0.9
-lark-parser==0.7.2
+lark-parser==0.7.5
 more-itertools==7.2.0
-pluggy==0.12.0
+pluggy==0.13.0
 py==1.8.0
-pytest==5.1.2
+pytest==5.1.3
 readline==6.2.4.1
 six==1.12.0
 typing-extensions==3.7.4


### PR DESCRIPTION
Bump pytest from 5.1.2 to 5.1.3
Bump lark-parser from 0.7.2 to 0.7.5
Bump pluggy from 0.12.0 to 0.13.0
Bump hypothesis from 4.32.2 to 4.36.2