### PR TITLE
Sort imports

### DIFF
--- a/benchmarks/bnb.py
+++ b/benchmarks/bnb.py
@@ -1,11 +1,11 @@
-import sys
 import logging
+import sys
 import time
+
+from rdflib.graph import Graph
 
 from hexastore import turtle
 from hexastore.memory import InMemoryHexastore
-
-from rdflib.graph import Graph
 
 logger = logging.getLogger(__name__)
 

--- a/hexastore/bisect.py
+++ b/hexastore/bisect.py
@@ -1,6 +1,7 @@
 """Bisection algorithms."""
 
-from typing import Sequence, TypeVar, Optional, Callable, cast
+from typing import Callable, Optional, Sequence, TypeVar, cast
+
 from .typing import Comparable
 
 T = TypeVar("T")

--- a/hexastore/engine.py
+++ b/hexastore/engine.py
@@ -1,12 +1,12 @@
-from dataclasses import dataclass
 import functools
-from typing import Any, Sequence, Union, Tuple, Iterator, List, TYPE_CHECKING, AbstractSet
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, AbstractSet, Any, Iterator, List, Sequence, Tuple, Union
 
 import attr
 
-from .ast import Variable, Order, IRI, OrderCondition
+from .ast import IRI, Order, OrderCondition, Variable
 from .model import Solution
-from .typing import Hexastore, Triple, Term
+from .typing import Hexastore, Term, Triple
 from .util import triple_map
 
 IS_NOT = IRI("http://example.org/isNot")

--- a/hexastore/forward_reasoner.py
+++ b/hexastore/forward_reasoner.py
@@ -1,5 +1,5 @@
-from collections import defaultdict
 import logging
+from collections import defaultdict
 from typing import List, Optional, Tuple
 
 from . import engine

--- a/hexastore/generic_rule.py
+++ b/hexastore/generic_rule.py
@@ -1,6 +1,6 @@
 import logging
 import pkgutil
-from typing import List, Union, Tuple, Callable
+from typing import Callable, List, Tuple, Union
 
 import attr
 from lark import Lark, Transformer, v_args

--- a/hexastore/index.py
+++ b/hexastore/index.py
@@ -1,6 +1,5 @@
 from .ast import Variable
 
-
 SUBJECT = 1
 PREDICATE = 2
 OBJECT = 4

--- a/hexastore/memory.py
+++ b/hexastore/memory.py
@@ -1,26 +1,26 @@
+import functools
+import itertools
 from collections import defaultdict
 from dataclasses import dataclass
-import itertools
-import functools
 from typing import (
-    Any,
-    Tuple,
-    Optional,
-    Mapping,
-    Iterable,
-    Union,
-    Sequence,
-    ValuesView,
     AbstractSet,
+    Any,
+    Callable,
+    Iterable,
     Iterator,
     List,
-    Callable,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+    ValuesView,
 )
 
-from .ast import Order, TripleStatus, TripleStatusItem, BlankNode
+from .ast import BlankNode, Order, TripleStatus, TripleStatusItem
 from .model import Key
-from .sorted import SortedList, SortedMapping, DefaultSortedMapping
-from .typing import Term, Triple, MutableIndex, MutableOrderedMapping
+from .sorted import DefaultSortedMapping, SortedList, SortedMapping
+from .typing import MutableIndex, MutableOrderedMapping, Term, Triple
 from .util import triple_map
 
 

--- a/hexastore/model.py
+++ b/hexastore/model.py
@@ -1,10 +1,10 @@
-import io
 import functools
-from typing import List, Dict, Union, Optional, Tuple, overload, TypeVar, AbstractSet
+import io
+from typing import AbstractSet, Dict, List, Optional, Tuple, TypeVar, Union, overload
 
 from immutables import Map
 
-from .ast import TYPE_ORDER_MAP, Order, Variable, OrderCondition
+from .ast import TYPE_ORDER_MAP, Order, OrderCondition, Variable
 from .typing import Term, Triple
 
 T = TypeVar("T")

--- a/hexastore/sorted.py
+++ b/hexastore/sorted.py
@@ -1,3 +1,4 @@
+import bisect
 import functools
 import typing
 from typing import (
@@ -9,18 +10,16 @@ from typing import (
     Iterator,
     List,
     Optional,
-    overload,
     Sequence,
     Tuple,
     Union,
     ValuesView,
     cast,
+    overload,
 )
-import bisect
 
 from .ast import Order
 from .typing import Comparable, MutableOrderedMapping
-
 
 T = typing.TypeVar("T")
 U = typing.TypeVar("U", bound=Comparable)

--- a/hexastore/turtle.py
+++ b/hexastore/turtle.py
@@ -1,11 +1,11 @@
 import decimal
 import logging
 import pkgutil
-from typing import Union, Tuple, Optional, Dict
+from typing import Dict, Optional, Tuple, Union
 
 from lark import Lark, Transformer, v_args
 
-from .ast import IRI, Variable, BlankNode, LangTaggedString, TypedLiteral
+from .ast import IRI, BlankNode, LangTaggedString, TypedLiteral, Variable
 from .namespace import Namespace
 
 logger = logging.getLogger(__name__)

--- a/hexastore/turtle_serialiser.py
+++ b/hexastore/turtle_serialiser.py
@@ -1,8 +1,8 @@
+import decimal
 from collections import defaultdict
 from dataclasses import dataclass
-import decimal
 
-from .ast import IRI, BlankNode, TypedLiteral, LangTaggedString
+from .ast import IRI, BlankNode, LangTaggedString, TypedLiteral
 
 TYPE = IRI("http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
 

--- a/hexastore/typing.py
+++ b/hexastore/typing.py
@@ -1,9 +1,10 @@
-from typing import Union, Any, Tuple, Mapping, ItemsView, MutableMapping
 import typing
-from typing_extensions import Protocol
 from abc import abstractmethod
+from typing import Any, ItemsView, Mapping, MutableMapping, Tuple, Union
 
-from .ast import IRI, TripleStatus, Order
+from typing_extensions import Protocol
+
+from .ast import IRI, Order, TripleStatus
 
 _C = typing.TypeVar("_C", bound="Comparable")
 

--- a/hexastore/util.py
+++ b/hexastore/util.py
@@ -1,5 +1,5 @@
 import itertools
-from typing import TypeVar, Callable, Tuple
+from typing import Callable, Tuple, TypeVar
 
 from .model import Key
 

--- a/mutant.py
+++ b/mutant.py
@@ -1,16 +1,16 @@
-import sys
 import contextlib
 import logging
-from typing import Dict
+import sys
 import time
+from typing import Dict
 
 import click
 
 from hexastore import generic_rule, turtle, turtle_serialiser
 from hexastore.ast import IRI
-from hexastore.namespace import Namespace
-from hexastore.memory import VersionedInMemoryHexastore
 from hexastore.default_forward_reasoner import default_forward_reasoner
+from hexastore.memory import VersionedInMemoryHexastore
+from hexastore.namespace import Namespace
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -1,9 +1,9 @@
 from unittest import mock
 
-from hexastore.ast import IRI, Variable, BlankNode, TripleStatus, TripleStatusItem
-from hexastore.model import Solution, Key
-
 import pytest
+
+from hexastore.ast import IRI, BlankNode, TripleStatus, TripleStatusItem, Variable
+from hexastore.model import Key, Solution
 
 DAVE_SMITH = IRI("http://example.com/dave-smith")
 ERIC_MILLER = IRI("http://example.com/eric-miller")

--- a/tests/test_default_forward_reasoner.py
+++ b/tests/test_default_forward_reasoner.py
@@ -2,8 +2,8 @@ import pytest
 
 from hexastore.ast import IRI, Variable
 from hexastore.blank_node_factory import BlankNodeFactory
-from hexastore.memory import VersionedInMemoryHexastore
 from hexastore.default_forward_reasoner import default_forward_reasoner
+from hexastore.memory import VersionedInMemoryHexastore
 
 A = IRI("http://example.com/A")
 B = IRI("http://example.com/B")

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,10 +1,9 @@
 import pytest
 
-from hexastore.ast import IRI, Variable, OrderCondition, Order
+from hexastore.ast import IRI, Order, OrderCondition, Variable
 from hexastore.blank_node_factory import BlankNodeFactory
-from hexastore.memory import VersionedInMemoryHexastore
 from hexastore.engine import execute
-
+from hexastore.memory import VersionedInMemoryHexastore
 
 DAVE_SMITH = IRI("http://example.com/dave-smith")
 ERIC_MILLER = IRI("http://example.com/eric-miller")

--- a/tests/test_forward_reasoner.py
+++ b/tests/test_forward_reasoner.py
@@ -4,9 +4,9 @@ import pytest
 
 from hexastore.ast import IRI, BlankNode
 from hexastore.blank_node_factory import BlankNodeFactory
+from hexastore.forward_reasoner import ForwardReasoner
 from hexastore.memory import VersionedInMemoryHexastore
 from hexastore.model import Key
-from hexastore.forward_reasoner import ForwardReasoner
 from hexastore.util import triple_map
 
 A = IRI("http://example.com/A")

--- a/tests/test_generic_rule.py
+++ b/tests/test_generic_rule.py
@@ -1,14 +1,14 @@
 import pkgutil
 
-from lark import Lark
 import pytest
+from lark import Lark
 
 from hexastore import generic_rule
+from hexastore.ast import IRI, Variable
 from hexastore.blank_node_factory import BlankNodeFactory
-from hexastore.ast import Variable, IRI
+from hexastore.forward_reasoner import ForwardReasoner
 from hexastore.memory import VersionedInMemoryHexastore
 from hexastore.namespace import Namespace
-from hexastore.forward_reasoner import ForwardReasoner
 
 A = IRI("http://example.com/A")
 B = IRI("http://example.com/B")

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -2,8 +2,7 @@ import pytest
 
 from hexastore.ast import IRI, TripleStatus, TripleStatusItem
 from hexastore.blank_node_factory import BlankNodeFactory
-from hexastore.memory import VersionedInMemoryHexastore, TrunkPayload, InMemoryHexastore
-
+from hexastore.memory import InMemoryHexastore, TrunkPayload, VersionedInMemoryHexastore
 
 DAVE_SMITH = IRI("http://example.com/dave-smith")
 ERIC_MILLER = IRI("http://example.com/eric-miller")

--- a/tests/test_sorted.py
+++ b/tests/test_sorted.py
@@ -1,10 +1,10 @@
 import random
 
+import hypothesis.strategies as st
 import pytest
 from hypothesis import given
-import hypothesis.strategies as st
 
-from hexastore.sorted import SortedList, SortedMapping, Order
+from hexastore.sorted import Order, SortedList, SortedMapping
 
 
 @pytest.mark.sorted

--- a/tests/test_turtle.py
+++ b/tests/test_turtle.py
@@ -1,16 +1,15 @@
-from decimal import Decimal
 import io
-import textwrap
 import pkgutil
+import textwrap
+from decimal import Decimal
 
 import pytest
-
 from lark import Lark, Token
 
 from hexastore.ast import IRI, LangTaggedString, TypedLiteral
 from hexastore.blank_node_factory import BlankNodeFactory
-from hexastore.model import Key
 from hexastore.memory import VersionedInMemoryHexastore
+from hexastore.model import Key
 from hexastore.turtle import parse
 from hexastore.turtle_serialiser import serialise
 


### PR DESCRIPTION
`isort --multi-line=3 --trailing-comma --force-grid-wrap=0 --use-parentheses --line-width=120 -rc benchmarks/ examples/ hexastore/ tests/ mutant.py`