### PR TITLE
Bump dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,14 +4,14 @@ cffi==1.12.3
 Click==7.0
 dataclasses==0.6; python_version < '3.7'
 greenlet==0.4.13
-hypothesis==4.36.2
+hypothesis==4.37.0
 immutables==0.9
 lark-parser==0.7.5
 more-itertools==7.2.0
-msgpack==0.6.1
+msgpack==0.6.2
 pluggy==0.13.0
 py==1.8.0
-pytest==5.1.3
+pytest==5.2.0
 readline==6.2.4.1
 six==1.12.0
 typing-extensions==3.7.4


### PR DESCRIPTION
Bump pytest from 5.1.3 to 5.2.0
Bump hypothesis from 4.36.2 to 4.37.0
Bump msgpack from 0.6.1 to 0.6.2